### PR TITLE
fix(cardToMiddle): scale datum.y by zoom so vertical centering works at any zoom

### DIFF
--- a/src/handlers/view-handlers.ts
+++ b/src/handlers/view-handlers.ts
@@ -45,7 +45,7 @@ type CardToMiddleProps = {
   transition_time?: number
 }
 export function cardToMiddle({datum, svg, svg_dim, scale, transition_time}: CardToMiddleProps) {
-  const k = scale || 1, x = svg_dim.width/2-datum.x*k, y = svg_dim.height/2-datum.y,
+  const k = scale || 1, x = svg_dim.width/2-datum.x*k, y = svg_dim.height/2-datum.y*k,
     t = {k, x: x/k, y: y/k}
   positionTree({t, svg, transition_time})
 }


### PR DESCRIPTION
Fixes #102.

`cardToMiddle` scales `datum.x` by the zoom factor `k` but leaves `datum.y` unscaled, so centering a node is only correct at `k = 1` and drifts vertically by `datum.y · (k − 1)` at any other zoom — the deeper the node, the larger the offset. In practice, clicking/centering a deep node while zoomed in or out jumps to empty space above/below the tree.

### Change
```diff
- const k = scale || 1, x = svg_dim.width/2-datum.x*k, y = svg_dim.height/2-datum.y,
+ const k = scale || 1, x = svg_dim.width/2-datum.x*k, y = svg_dim.height/2-datum.y*k,
    t = {k, x: x/k, y: y/k}
```

### Why it's correct
`positionTree` applies `d3.zoomIdentity.scale(k).translate(t.x, t.y)` → transform `{k, x: W/2 − datum.x·k, y: H/2 − datum.y·k}` after the fix. A node at view-coords `(datum.x, datum.y)` then renders at:

- x = (W/2 − datum.x·k) + datum.x·k = **W/2**
- y = (H/2 − datum.y·k) + datum.y·k = **H/2**

i.e. exactly centered for any `k`. Before the fix, `y` resolved to `H/2 + datum.y·(k − 1)`. `x` was already correct and is unchanged.

One-line change, no API change. (See #102 for the full derivation and repro.)