### PR TITLE
fix(layout): center a person between their spouses (multi-spouse layout)

### DIFF
--- a/src/layout/calculate-tree.ts
+++ b/src/layout/calculate-tree.ts
@@ -172,20 +172,37 @@ export default function calculateTree(data: Data, {
         if (d._ignore_spouses) spouses = spouses.filter(sp_id => !d._ignore_spouses!.includes(sp_id))
         if (spouses.length > 0) {
           if (one_level_rels && d.depth > 0) continue
-          const side = d.data.data.gender === "M" ? -1 : 1;  // female on right
-          d.x += spouses.length/2*node_separation*side;
+          // Keep the person in the MIDDLE and fan their spouses out to
+          // alternating sides (spouse 1 one side, spouse 2 the other, further
+          // spouses farther out), then recenter the whole cluster on the
+          // person's slot. This way each couple's children descend from between
+          // the correct pair, instead of all spouses stacking on one
+          // (gender-based) side. Order follows relationship order, not gender;
+          // children are sorted to match in sortChildrenWithSpouses.
+          const offsets = spouses.map((_sp, i) => {
+            const dir = i % 2 === 0 ? 1 : -1
+            const dist = Math.floor(i / 2) + 1  // 1,1,2,2,3,3...
+            return -(node_separation * dist) * dir
+          })
+          // Mean over the person (offset 0) + every spouse, so the cluster stays
+          // centered on the person's original x.
+          const center = offsets.reduce((a, b) => a + b, 0) / (offsets.length + 1)
+          const base_x = d.x
+          d.x = base_x - center
           spouses.forEach((sp_id, i) => {
             const spouse:TreeDatum = {
               data: data_stash.find(d0 => d0.id === sp_id) as Datum,
               added: true,
               depth: d.depth,
               spouse: d,
-              x: d.x-(node_separation*(i+1))*side,
+              x: base_x + offsets[i] - center,
               y: d.y,
               tid: `${d.data.id}-spouse-${i}`,
             }
-            spouse.sx = i > 0 ? spouse.x : spouse.x + (node_separation/2)*side
-            spouse.sy = i > 0 ? spouse.y : spouse.y + (node_separation/2)*side
+            // Anchor the couple link at the midpoint toward the person.
+            const toward = spouse.x < d.x ? 1 : -1
+            spouse.sx = spouse.x + toward * (node_separation / 2)
+            spouse.sy = spouse.y
             if (!d.spouses) d.spouses = []
             d.spouses.push(spouse)
             tree.push(spouse)

--- a/src/layout/handlers.ts
+++ b/src/layout/handlers.ts
@@ -12,8 +12,9 @@ export function sortChildrenWithSpouses(children: Datum[], datum: Datum, data: D
     const a_i = a_p2 ? spouses.indexOf(a_p2.id) : -1
     const b_i = b_p2 ? spouses.indexOf(b_p2.id) : -1
 
-    if (datum.data.gender === "M") return a_i - b_i
-    else return b_i - a_i
+    // Order children by spouse order (ascending), independent of gender, so each
+    // couple's children sit next to the matching spouse in the centered layout.
+    return a_i - b_i
   })
 }
 


### PR DESCRIPTION
Fixes #104.

### Problem
`calculateTree` positions spouses by shifting the person to a gender-based side and stacking **all** spouses on the other side. With 2+ spouses the person ends up at the edge of their cluster and children of different couples can't descend from between the correct pair.

### Change
- **`src/layout/calculate-tree.ts`** — keep the person centered; fan spouses to alternating sides (`offsets` = ∓`node_separation`, ∓2·`node_separation`, …), then subtract the cluster mean (person + spouses) so it stays centered on the person's original `x`. Couple-link anchors (`spouse.sx`) point toward the person.
- **`src/layout/handlers.ts`** (`sortChildrenWithSpouses`) — order children by spouse index ascending, independent of gender, so each couple's children sit under the matching spouse.

### Result
Person in the middle, spouses fanned symmetrically, each couple's children descending from between the correct pair. (Diagram for a 2-spouse person — `S1 — P — S2`, children grouped under `S1–P` and `P–S2`.)

### Notes / trade-offs
- **This changes the default layout.** Single-spouse becomes symmetric (couple centered around the person's slot), and the gender-based "female on right" side is no longer used. If you'd rather preserve the current default, I'm glad to put this behind an option (e.g. `spouse_layout: 'centered' | 'sided'`) — let me know your preference.
- Built locally with `npm run build` — compiles cleanly (only the pre-existing named/default-export warnings). `dist/` is gitignored, so this is a source-only change.
- Running in production in a downstream genealogy app with multi-spouse trees.

See #104 for the full description.